### PR TITLE
Fixed navbar buttons

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -612,6 +612,12 @@ pre code {
     font-size: 18px;
   }
 }
+
+section{
+  scroll-margin-top: 79px;
+}
+
+
 /* Small devices (tablets, 768px and up) */
 /* Medium devices (desktops, 992px and up) */
 /* Large devices (large desktops, 1200px and up) */

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -31,3 +31,14 @@ jQuery(document).ready(function($) {
 	});
 
 });
+
+let scrollButtons = document.querySelectorAll('.scrollto');
+
+scrollButtons.forEach((button) => {
+    let refId = button.attributes.getNamedItem('href').value.substring(1);
+    button.addEventListener('click', () => {
+        document.getElementById(refId).scrollIntoView({ block: 'start',  behavior: 'smooth'});
+    })
+});
+
+

--- a/index.html
+++ b/index.html
@@ -300,7 +300,6 @@
     <script type="text/javascript" src="assets/plugins/jquery-1.11.3.min.js"></script>
     <script type="text/javascript" src="assets/plugins/jquery.easing.1.3.js"></script>
     <script type="text/javascript" src="assets/plugins/bootstrap/js/bootstrap.min.js"></script>
-    <script type="text/javascript" src="assets/plugins/jquery-scrollTo/jquery.scrollTo.min.js"></script>
     <script type="text/javascript" src="assets/plugins/prism/prism.js"></script>
     <script type="text/javascript" src="assets/js/main.js"></script>
 </body>


### PR DESCRIPTION
Since jQuery.ScrollTo plugin outdated, navbar buttons aren't working in chrome and in other browsers have some bugs. I fixed that with vanilla js and added scroll-margin-top property to prevent content from being hidden underneath a fixed header. 